### PR TITLE
Fix Bootstrap WebJar path for npm-based structure-created-by-agentic

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -20,17 +20,14 @@
   <link th:href="@{/webjars/font-awesome/4.7.0/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
 
-</head>
-
-<body>
+</head><body>
 
   <nav class="navbar navbar-expand-lg navbar-dark" role="navigation">
     <div class="container-fluid">
       <a class="navbar-brand" th:href="@{/}"><span></span></a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main-navbar">
         <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="main-navbar" style>
+      </button><div class="collapse navbar-collapse" id="main-navbar" style>
 
         <ul class="navbar-nav me-auto mb-2 mb-lg-0" th:remove="all">
 
@@ -53,9 +50,7 @@
           <li th:replace="~{::menuItem ('/owners/find','owners','find owners','search','Find owners')}">
             <span class="fa fa-search" aria-hidden="true"></span>
             <span>Find owners</span>
-          </li>
-
-          <li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
+          </li><li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
             <span class="fa fa-th-list" aria-hidden="true"></span>
             <span>Veterinarians</span>
           </li>
@@ -74,8 +69,7 @@
         </ul>
       </div>
     </div>
-  </nav>
-  <div class="container-fluid">
+  </nav><div class="container-fluid">
     <div class="container xd-container">
 
       <th:block th:insert="${template}" />
@@ -92,7 +86,7 @@
     </div>
   </div>
 
-  <script th:src="@{/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/webjars/bootstrap/5.2.3/package/dist/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
This PR fixes the Bootstrap JS bundle loading issue by updating the WebJar path to match the npm-based structure.

Changes made:
- Updated the path in layout.html from `/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js` to `/webjars/bootstrap/5.2.3/package/dist/js/bootstrap.bundle.min.js`

This change aligns with the npm-based WebJar structure used in the application and should resolve the static resource loading issue.

Error ID: b2533902-46d1-11f0-8c71-ea5d04bd05f7
Environment: AGENTIC-DEV