### PR TITLE
Fix Bootstrap Resources Loading Issue-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
@@ -1,0 +1,17 @@
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry
+            .addResourceHandler("/webjars/**")
+            .addResourceLocations("/webjars/")
+            .resourceChain(true);
+    }
+}


### PR DESCRIPTION
This PR addresses the missing Bootstrap JavaScript resources issue by:

1. Adding proper WebMVC configuration for webjar resource handling
2. Configuring the resource chain for better resource resolution

Changes made:
- Added WebConfig.java with proper resource handler configuration
- Configured resource chain for better webjar resolution

Testing:
- The Bootstrap JavaScript resources should now be properly loaded
- UI functionality should be restored

Fixes the issue where bootstrap.bundle.min.js was not found.