### PR TITLE
Fix WebJars Bootstrap Resource 404 Error-created-by-agentic

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  web:
+    resources:
+      chain:
+        strategy:
+          content:
+            enabled: true
+            paths: /webjars/**
+      static-locations:
+        - classpath:/META-INF/resources/webjars/
+        - classpath:/static/
+        - classpath:/public/


### PR DESCRIPTION
This PR fixes the 404 error when accessing WebJar Bootstrap resources by:

1. Adding explicit WebJar resource configuration in application.yml
2. Configuring proper resource chain strategy for WebJar paths
3. Ensuring static resource locations are properly set

The changes will:
- Enable proper resolution of WebJar resources
- Fix the 404 errors when accessing Bootstrap resources
- Improve resource caching through the resource chain strategy

Testing:
1. Build the application with `mvn clean package -Pcss`
2. Verify Bootstrap resources are accessible at `/webjars/bootstrap/5.2.3/css/bootstrap.min.css`

Note: The css profile should be activated during build to ensure proper resource unpacking.