### PR TITLE
Fix Webjars Bootstrap 404 Error-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
@@ -1,0 +1,16 @@
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/")
+                .resourceChain(true);
+    }
+}


### PR DESCRIPTION
This PR fixes the 404 error when accessing Bootstrap resources via Webjars by:

1. Adding a proper WebMvcConfigurer configuration to handle Webjars resources correctly
2. Ensuring proper resource chain handling for Webjars

The changes include:
- Added WebConfig class implementing WebMvcConfigurer
- Configured proper resource handling for /webjars/** path
- Enabled resource chain optimization

This should resolve the 404 errors when accessing Bootstrap resources through Webjars.