### PR TITLE
Fix N+1 query performance issue in Vet.specialties relationship

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -23,9 +23,7 @@ import java.util.Set;
 
 import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
-import org.springframework.samples.petclinic.model.Person;
-
-import jakarta.persistence.Entity;
+import org.springframework.samples.petclinic.model.Person;import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -42,10 +40,10 @@ import jakarta.xml.bind.annotation.XmlElement;
  * @author Arjen Poutsma
  */
 @Entity
-@Table(name = "vets")
-public class Vet extends Person {
+@Table(name = "vets")public class Vet extends Person {
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@BatchSize(size = 10)
+	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "vet_specialties", joinColumns = @JoinColumn(name = "vet_id"),
 			inverseJoinColumns = @JoinColumn(name = "specialty_id"))
 	private Set<Specialty> specialties;

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -19,17 +19,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
-import org.springframework.beans.support.MutableSortDefinition;
+import java.util.Set;import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
-import org.springframework.samples.petclinic.model.Person;import jakarta.persistence.Entity;
+import org.springframework.samples.petclinic.model.Person;
+import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import jakarta.xml.bind.annotation.XmlElement;
+import org.hibernate.annotations.BatchSize;
 
 /**
  * Simple JavaBean domain object representing a veterinarian.
@@ -40,15 +40,14 @@ import jakarta.xml.bind.annotation.XmlElement;
  * @author Arjen Poutsma
  */
 @Entity
-@Table(name = "vets")public class Vet extends Person {
+@Table(name = "vets")
+public class Vet extends Person {
 
 	@BatchSize(size = 10)
 	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "vet_specialties", joinColumns = @JoinColumn(name = "vet_id"),
 			inverseJoinColumns = @JoinColumn(name = "specialty_id"))
-	private Set<Specialty> specialties;
-
-	protected Set<Specialty> getSpecialtiesInternal() {
+	private Set<Specialty> specialties;protected Set<Specialty> getSpecialtiesInternal() {
 		if (this.specialties == null) {
 			this.specialties = new HashSet<>();
 		}


### PR DESCRIPTION
## Problem
Critical N+1 query performance issue in spring-petclinic service affecting `/vets.html` endpoint with 5 repeated SQL queries instead of optimized batch operations.

**Issue ID:** e8efc2b4-5f5e-11f0-bbd9-0242ac160009
**Affected Endpoint:** HTTP GET /vets.html
**Trace ID:** E78ADC1B4AB172AAA6DAC2D716CB4E0D

## Solution
Modified the `Vet.specialties` relationship configuration to optimize query performance:

1. **Changed fetch strategy**: `FetchType.EAGER` → `FetchType.LAZY`
2. **Added batch optimization**: `@BatchSize(size = 10)` annotation
3. **Added required import**: `org.hibernate.annotations.BatchSize`

## Changes Made
- **File**: `src/main/java/org/springframework/samples/petclinic/vet/Vet.java`
- **Before**: `@ManyToMany(fetch = FetchType.EAGER)`
- **After**: `@BatchSize(size = 10)` + `@ManyToMany(fetch = FetchType.LAZY)`

## Expected Impact
This fix should reduce the 5 separate SQL queries to a single optimized batch query for the `/vets.html` endpoint, significantly improving performance.

## Testing
This follows the same solution pattern that was successfully applied to `Owner.pets` relationship in commit 30fee0f245235d98b888b1f904db1f734c756d9e.