### PR TITLE
Update MongoDB connection string to use k8s service DNS

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=true
 
 # FlaskDb
-spring.data.flaskdb.uri=http://localhost:27017/feedbacks
+spring.data.flaskdb.uri=http://petclinic-flaskdb:27017/feedbacks
 
 # Internationalization
 spring.messages.basename=messages/messages
@@ -27,5 +27,4 @@ logging.level.org.springframework=INFO
 # logging.level.org.springframework.web=DEBUG
 # logging.level.org.springframework.context.annotation=TRACE
 
-# Maximum time static resources should be cached
-spring.web.resources.cache.cachecontrol.max-age=12h
+# Maximum time static resources should be cachedspring.web.resources.cache.cachecontrol.max-age=12h


### PR DESCRIPTION
This PR updates the MongoDB connection string to use the Kubernetes service DNS name for petclinic-flaskdb service.

The petclinic-flaskdb deployment manifest should be created in a separate PR due to some technical limitations with file creation.