### PR TITLE
fix: set flaskdb StatefulSet replicas to 1

### DIFF
--- a/flaskdb-statefulset.yaml
+++ b/flaskdb-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 0
+  replicas: 1  # Updated from 0 to 1 to ensure database availability
   revisionHistoryLimit: 10
   selector:
     matchLabels:


### PR DESCRIPTION
## Description
This PR fixes the database connectivity issue affecting the `/api/clinic-feedback/count` endpoint by ensuring the flaskdb StatefulSet maintains one replica running at all times.

## Changes
- Updated `flaskdb-statefulset.yaml` to set `replicas: 1`
- Added comments explaining the requirement for minimum replica count

## Validation Steps
1. Apply the updated StatefulSet configuration
2. Verify flaskdb pod is running (`kubectl get pods`)
3. Test `/api/clinic-feedback/count` endpoint returns HTTP 200
4. Confirm no new database connectivity errors in monitoring

## Related Issues
Fixes database connectivity error (ID: ff76e9d8-81bc-11f0-8462-168ae57aaddf)