### PR TITLE
Fix: Set flaskdb StatefulSet replicas to 1

### DIFF
--- a/flaskdb-statefulset.yaml
+++ b/flaskdb-statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/component: petclinic-flaskdb
   name: petclinic-flaskdb
-  namespace: pet-agentic-dev
+   namespace: pet-agentic-dev
   resourceVersion: "168531759"
   uid: 9afe42b9-5e54-456f-8d1d-c361cf6facc6
 spec:
@@ -21,7 +21,7 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:


### PR DESCRIPTION
This PR fixes the connectivity issue between petclinic service and petclinic-flaskdb by setting the StatefulSet replica count to 1.

**Issue:** ff76fc16-81bc-11f0-8462-168ae57aaddf
**Change:** Updated flaskdb-statefulset.yaml to set replicas: 1

This minimal change will restore service functionality for the /api/clinic-feedback/count endpoint.