### PR TITLE
fix: Update flaskdb StatefulSet configuration

### DIFF
--- a/flaskdb-statefulset.yaml
+++ b/flaskdb-statefulset.yaml
@@ -21,14 +21,13 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: petclinic-flaskdb
   serviceName: petclinic-flaskdb
-  template:
-    metadata:
+  template:    metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: petclinic-flaskdb
@@ -43,22 +42,39 @@ spec:
         - -c
         env:
         - name: DATA_DIR
-          value: /data/db
+           value: /data/db
         image: python:3.11-slim
         imagePullPolicy: IfNotPresent
         name: flask-container
         ports:
         - containerPort: 27017
           protocol: TCP
-        resources: {}
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "200m"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 15
+          periodSeconds: 10
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /app
           name: flask-source
         - mountPath: /data/db
-          name: flaskdb-data
-      dnsPolicy: ClusterFirst
+          name: flaskdb-data      dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}


### PR DESCRIPTION
This PR addresses the connection issues with the petclinic-flaskdb service by updating the StatefulSet configuration with proper settings:

1. Set replicas to 1 to ensure the database service is running
2. Added resource limits and requests to prevent resource contention:
   - Requests: 256Mi memory, 100m CPU
   - Limits: 512Mi memory, 200m CPU
3. Implemented health checks:
   - Readiness probe: HTTP GET /health on port 5000
   - Liveness probe: HTTP GET /health on port 5000

These changes will ensure:
- The database service is always running with one replica
- Resource usage is properly managed
- Kubernetes can properly monitor container health

Fixes connection issues affecting the /api/clinic-feedback/count endpoint.
Related error: ff76e9d8-81bc-11f0-8462-168ae57aaddf