### PR TITLE
fix: Update StatefulSet replicas and database configuration

### DIFF
--- a/flaskdb-statefulset.yaml
+++ b/flaskdb-statefulset.yaml
@@ -21,14 +21,13 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: petclinic-flaskdb
   serviceName: petclinic-flaskdb
-  template:
-    metadata:
+  template:    metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: petclinic-flaskdb

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=true
 
 # FlaskDb
-spring.data.flaskdb.uri=http://localhost:27017/feedbacks
+spring.data.flaskdb.uri=mongodb://petclinic-flaskdb:27017/feedbacks
 
 # Internationalization
 spring.messages.basename=messages/messages


### PR DESCRIPTION
This PR fixes the database connectivity issues in the /api/clinic-feedback/count endpoint by:

1. Setting StatefulSet replicas to 1 to ensure database pods are running
2. Updating the database connection configuration to use the correct service name

These changes resolve the HTTP 500 errors by ensuring:
- Database pods are running (StatefulSet replicas > 0)
- Application can properly connect to the database using the correct service name

Testing:
1. Verify GET /api/clinic-feedback/count returns HTTP 200
2. Confirm petclinic service can connect to petclinic-flaskdb:27017
3. Check application logs for no connection errors
4. Verify database pods are running

Fixes #[Issue number]