### PR TITLE
Fix database connection configuration for petclinic-flaskdb service

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=true
 
 # FlaskDb
-spring.data.flaskdb.uri=http://localhost:27017/feedbacks
+spring.data.flaskdb.uri=http://petclinic-flaskdb:27017/feedbacks
 
 # Internationalization
 spring.messages.basename=messages/messages


### PR DESCRIPTION
This PR fixes the database connection configuration in application.properties by updating the connection URL to use the correct Kubernetes service name instead of localhost.

Changes:
- Updated spring.data.flaskdb.uri from http://localhost:27017/feedbacks to http://petclinic-flaskdb:27017/feedbacks

This fixes the connectivity issues with the /api/clinic-feedback/count endpoint by ensuring the application connects to the correct database service within the Kubernetes cluster.

Fixes issue with error ID: ff76fc16-81bc-11f0-8462-168ae57aaddf