### PR TITLE
fix: implement resource limits and optimize probe timing for petclinic pods

### DIFF
--- a/petshop-chart/templates/deployment.yaml
+++ b/petshop-chart/templates/deployment.yaml
@@ -52,13 +52,20 @@ spec:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.resources | nindent 12 }}      {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/petshop-chart/values.yaml
+++ b/petshop-chart/values.yaml
@@ -56,17 +56,22 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi  # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
This PR addresses pod restart issues in the petclinic service by implementing proper resource management and probe configurations.

Changes made:
1. Added resource limits and requests to values.yaml:
   - requests: cpu=200m, memory=512Mi
   - limits: cpu=1000m, memory=1Gi

2. Updated probe configurations in deployment.yaml:
   - Added initialDelaySeconds: 30
   - Set periodSeconds: 10
   - Added timeoutSeconds: 5
   - Added failureThreshold: 3

These changes will help prevent pod restarts by:
- Ensuring proper resource allocation
- Implementing appropriate probe timing parameters
- Preventing unnecessary restarts due to aggressive health checks

Testing:
- Monitor pod status using 'kubectl get pods -n agentic'
- Verify pods are running stably without restarts
- Check pod restart counts remain at 0
- Verify application logs show no crash patterns
- Confirm health checks are passing consistently